### PR TITLE
Free buffer pointer allocated by getline

### DIFF
--- a/center.c
+++ b/center.c
@@ -101,8 +101,8 @@ main(int argc, char **argv)
 void
 center(FILE *fp)
 {
-	char *line = NULL;
-	size_t bs = 0;
+	static char *line = NULL;
+	static size_t bs = 0;
 
 	while (getline(&line, &bs, fp) != -1) {
 		int len, tabs = 0;


### PR DESCRIPTION
getline allocate/reallocates memory dynamically (hence why it needs a **buffer as argument). This pointer needs to be freed.

This would lead to memory leaks since `center()` is called repeatedly in the loop in `main()`.